### PR TITLE
Use Alpine Linux instead of Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:stable
+FROM alpine:3.4
 
 EXPOSE 5000
 WORKDIR /app
 ENTRYPOINT ["nginx", "-c",  "/nginx.conf"]
 
-RUN apt-get update && apt-get install -y nginx-light
+RUN apk add --no-cache nginx
 ADD nginx.conf /
 
 ONBUILD ADD . /app

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,9 @@
 daemon off;
+pid /run/nginx.pid;
 error_log stderr;
 worker_processes 2;
 events {
-       worker_connections 1024;
+    worker_connections 1024;
 }
 http {
     include /etc/nginx/mime.types;


### PR DESCRIPTION
This PR replaces Debian with Alpine, reducing image size from 140Mi to 6Mi (otherwise being fully backwards-compatible). I thought you might find this useful. If not, that's fine, I forked off the project anyway as I needed some other customizations. Thanks for sharing it in the first place.
